### PR TITLE
synchrony fix

### DIFF
--- a/share/avst-app/lib/product/confluence/modify.d/41set_connector_protocol
+++ b/share/avst-app/lib/product/confluence/modify.d/41set_connector_protocol
@@ -16,16 +16,10 @@
 # This will set a connector protocol for each Confleunce connector as long as we are running Confluence 6 and above
 # the synchrony service requires the protocol to be set to "org.apache.coyote.http11.Http11NioProtocol"
 
-# Exit failing on any error
-set -e
-# Ensure that all variables have been set
-set -u
 
 VERSIONS_COMPARED_RESULT=$( run_cmd "version_comparison '5.99.99' '<' '${VERSION}'" )
 if [[ "$(get_std_return ${VERSIONS_COMPARED_RESULT})" == "0" ]]; then
     debug "confluence/modify/set_connector_protocol: Confluence version greater or equal to 6.0.0, attempting to set protocol for each connector"
-
-	SERVER_XML_FILE="${TOMCAT_DIR}/conf/server.xml"
 
 	[[ ! -r ${SERVER_XML_FILE} ]] && \
 	    fatal "confluence/modify/set_connector_protocol: Could not find server.xml" && \
@@ -54,10 +48,8 @@ if [[ "$(get_std_return ${VERSIONS_COMPARED_RESULT})" == "0" ]]; then
 	    # Re-enable variable checking
 	    set -u
 
-	    # TODO: Remove hardcoded values and add secure flag
 	    AUGEAS_DOC=$(printf "${AUGEAS_DOC}\n\
 	set \$service/Connector[${index}]/#attribute/protocol ${CONNECTOR_PROTOCOL}")
-
 
 	    index=$(( $index+1 ))
 	done

--- a/share/avst-app/lib/product/confluence/modify.d/41set_connector_protocol
+++ b/share/avst-app/lib/product/confluence/modify.d/41set_connector_protocol
@@ -21,7 +21,6 @@ set -e
 # Ensure that all variables have been set
 set -u
 
-parse_and_test_version ".tar.gz"
 VERSIONS_COMPARED_RESULT=$( run_cmd "version_comparison '5.99.99' '<' '${VERSION}'" )
 if [[ "$(get_std_return ${VERSIONS_COMPARED_RESULT})" == "0" ]]; then
     debug "confluence/modify/set_connector_protocol: Confluence version greater or equal to 6.0.0, attempting to set protocol for each connector"
@@ -33,7 +32,6 @@ if [[ "$(get_std_return ${VERSIONS_COMPARED_RESULT})" == "0" ]]; then
 	    exit 1
 
 	AUGEAS_DOC=""
-
 
 	# The first connector will not have an index
 	# the seq -> tail generates _0 _1 etc and then drops the first one
@@ -76,4 +74,4 @@ if [[ "$(get_std_return ${VERSIONS_COMPARED_RESULT})" == "0" ]]; then
 EOF
 else
     debug "confluence/modify/set_connector_protocol: Confluence version less than 6.0.0, no need to attempt to set connector protocol"
- fi
+fi

--- a/share/avst-app/lib/product/confluence/modify.d/41set_connector_protocol
+++ b/share/avst-app/lib/product/confluence/modify.d/41set_connector_protocol
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2015 Adaptavist.com Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This will set a connector protocol for each Confleunce connector as long as we are running Confluence 6 and above
+# the synchrony service requires the protocol to be set to "org.apache.coyote.http11.Http11NioProtocol"
+
+# Exit failing on any error
+set -e
+# Ensure that all variables have been set
+set -u
+
+parse_and_test_version ".tar.gz"
+VERSIONS_COMPARED_RESULT=$( run_cmd "version_comparison '5.99.99' '<' '${VERSION}'" )
+if [[ "$(get_std_return ${VERSIONS_COMPARED_RESULT})" == "0" ]]; then
+    debug "confluence/modify/set_connector_protocol: Confluence version greater or equal to 6.0.0, attempting to set protocol for each connector"
+
+	SERVER_XML_FILE="${TOMCAT_DIR}/conf/server.xml"
+
+	[[ ! -r ${SERVER_XML_FILE} ]] && \
+	    fatal "confluence/modify/set_connector_protocol: Could not find server.xml" && \
+	    exit 1
+
+	AUGEAS_DOC=""
+
+
+	# The first connector will not have an index
+	# the seq -> tail generates _0 _1 etc and then drops the first one
+	# The list we end up with is '' '_1' '_2' etc
+	CONNECTOR_COUNT="${CONNECTOR_COUNT:-1}"
+	ADDTITIONAL_SEQ=""
+	[[ "${CONNECTOR_COUNT}" -gt "1" ]] && \
+	    ADDTITIONAL_SEQ=$(seq -f "_%g" 1 $((${CONNECTOR_COUNT} - 1)))
+
+	index=1
+
+	for i in '' ${ADDTITIONAL_SEQ} ; do
+	    # disable variable checking
+	    set +u
+
+	    # work out connector protocol
+	    CONNECTOR_PROTOCOL=$( eval echo \$"CONNECTOR_PROTOCOL${i}" )
+	    CONNECTOR_PROTOCOL=${CONNECTOR_PROTOCOL:-"org.apache.coyote.http11.Http11NioProtocol"}
+
+	    # Re-enable variable checking
+	    set -u
+
+	    # TODO: Remove hardcoded values and add secure flag
+	    AUGEAS_DOC=$(printf "${AUGEAS_DOC}\n\
+	set \$service/Connector[${index}]/#attribute/protocol ${CONNECTOR_PROTOCOL}")
+
+
+	    index=$(( $index+1 ))
+	done
+
+	augtool -LA ${AUGTOOL_DEBUG} <<EOF
+	set /augeas/load/xml/lens "Xml.lns"
+	set /augeas/load/xml/incl "${SERVER_XML_FILE}"
+	load
+	defvar server_xml "/files/${SERVER_XML_FILE}"
+	defvar service \$server_xml/Server/Service
+	${AUGEAS_DOC}
+	save
+	print /augeas//error
+EOF
+else
+    debug "confluence/modify/set_connector_protocol: Confluence version less than 6.0.0, no need to attempt to set connector protocol"
+ fi


### PR DESCRIPTION
added logic to set connector protocol for confluence 6, this is needed as synchrony breaks without it