### PR TITLE
Added support for ElasticSearch 6.5 on Bitbucket 6.x

### DIFF
--- a/share/avst-app/lib/product/bitbucket/install-service.d/05install_elasticsearch_service
+++ b/share/avst-app/lib/product/bitbucket/install-service.d/05install_elasticsearch_service
@@ -66,6 +66,20 @@ if [[ "$(get_std_return ${VERSIONS_COMPARED_RESULT})" == "0" ]]; then
     SEARCH_LOG_DIR="${SEARCH_LOG_DIR:-${HOME_DIR}/log/search}"
     SEARCH_BIN_DIR="${SEARCH_BIN_DIR:-${INSTALL_DIR}/elasticsearch/bin}"
 
+    # Bitbucket >= 6.0.0 used ElasticSearch 6.5, path.conf has been replaced by the environment variable ES_PATH_CONF
+    VERSIONS_COMPARED_RESULT=$( run_cmd "version_comparison '5.16.99' '<' '${VERSION}'" )
+    if [[ "$(get_std_return ${VERSIONS_COMPARED_RESULT})" == "0" ]]; then
+        cp "${INSTALL_DIR}/elasticsearch/config-template/jvm.options" "${SEARCH_HOME_DIR}/jvm.options"
+        chown "${INSTANCE_USER}:${INSTANCE_GROUP}" "${SEARCH_HOME_DIR}/jvm.options"
+        CONFIG_ARG_PATH_CONF=""
+        ENV_PATH_CONF="ES_PATH_CONF=${SEARCH_HOME_DIR}"
+    else
+        CONFIG_ARG_PATH_CONF="-${ES_CONFIG_ARG}path.conf=${SEARCH_HOME_DIR}"
+        ENV_PATH_CONF=""
+    fi
+
+
+
     if [ -L /sbin/init ] &&  [[ $(readlink /sbin/init) == *"systemd"* ]]; then
         SYSTEMD_HOME="${SYSTEMD_HOME:-/etc/systemd/system/}"
         cd "${SYSTEMD_HOME}"
@@ -79,6 +93,8 @@ if [[ "$(get_std_return ${VERSIONS_COMPARED_RESULT})" == "0" ]]; then
             sed "s#<SEARCH_LOG_DIR>#${SEARCH_LOG_DIR}#g" | \
             sed "s#<SEARCH_BIN_DIR>#${SEARCH_BIN_DIR}#g" | \
             sed "s#<SEARCH_HOME_DIR>#${SEARCH_HOME_DIR}#g" | \
+            sed "s#<CONFIG_ARG_PATH_CONF>#${CONFIG_ARG_PATH_CONF}#g" | \
+            sed "s#<ENV_PATH_CONF>#Environment=${ENV_PATH_CONF}#g" | \
             sed "s#<CONFIG_ARG>#${ES_CONFIG_ARG}#g" > "${SEARCH_SERVICE_NAME}.service"
     else
         INIT_HOME="${INIT_HOME:-/etc}"
@@ -90,8 +106,11 @@ if [[ "$(get_std_return ${VERSIONS_COMPARED_RESULT})" == "0" ]]; then
             sed "s#<SEARCH_LOG_DIR>#${SEARCH_LOG_DIR}#g" | \
             sed "s#<SEARCH_BIN_DIR>#${SEARCH_BIN_DIR}#g" | \
             sed "s#<SEARCH_HOME_DIR>#${SEARCH_HOME_DIR}#g" | \
+            sed "s#<CONFIG_ARG_PATH_CONF>#${CONFIG_ARG_PATH_CONF}#g" | \
+            sed "s#<ENV_PATH_CONF>#env ${ENV_PATH_CONF}#g" | \
             sed "s#<CONFIG_ARG>#${ES_CONFIG_ARG}#g" > "${SEARCH_SERVICE_NAME}.conf"
         AND_SEARCH_SERVICE="and started ${SEARCH_SERVICE_NAME}"        
     fi
+
 fi
 

--- a/share/avst-app/systemd/atlas-search.service
+++ b/share/avst-app/systemd/atlas-search.service
@@ -10,8 +10,9 @@ After=syslog.target network.target
 User=<INSTANCE_USER>
 Group=<INSTANCE_GROUP>
 Type=forking
+<ENV_PATH_CONF>
 PIDFile=<SEARCH_HOME_DIR>/elasticsearch.pid
-ExecStart=<SEARCH_BIN_DIR>/elasticsearch -d -p <SEARCH_HOME_DIR>/elasticsearch.pid -<CONFIG_ARG>path.conf=<SEARCH_HOME_DIR> -<CONFIG_ARG>path.logs=<SEARCH_LOG_DIR> -<CONFIG_ARG>path.data=<SEARCH_HOME_DIR>/data
+ExecStart=<SEARCH_BIN_DIR>/elasticsearch -d -p <SEARCH_HOME_DIR>/elasticsearch.pid <CONFIG_ARG_PATH_CONF> -<CONFIG_ARG>path.logs=<SEARCH_LOG_DIR> -<CONFIG_ARG>path.data=<SEARCH_HOME_DIR>/data
 ExecStop=/usr/bin/kill -15 $MAINPID
 ExecStopPost=/bin/sleep 5
 Restart=always

--- a/share/avst-app/upstart/upstart-atlas-search.conf
+++ b/share/avst-app/upstart/upstart-atlas-search.conf
@@ -28,8 +28,11 @@ console log
 setuid <INSTANCE_USER>
 setgid <INSTANCE_GROUP>
 
+<ENV_PATH_CONF>
+
 # UPSTART_JOB is set to the filename, which will be the Instance Name
-exec <SEARCH_BIN_DIR>/elasticsearch -p <SEARCH_HOME_DIR>/elasticsearch.pid -<CONFIG_ARG>path.conf=<SEARCH_HOME_DIR> -<CONFIG_ARG>path.logs=<SEARCH_LOG_DIR> -<CONFIG_ARG>path.data=<SEARCH_HOME_DIR>/data
+exec <SEARCH_BIN_DIR>/elasticsearch -p <SEARCH_HOME_DIR>/elasticsearch.pid <CONFIG_ARG_PATH_CONF> -<CONFIG_ARG>path.logs=<SEARCH_LOG_DIR> -<CONFIG_ARG>path.data=<SEARCH_HOME_DIR>
+/data
 
 # sleep for 5 seconds after stop, work around for fast restarts
 post-stop exec sleep 5


### PR DESCRIPTION
Main change relats to the path.conf:

> Previous versions of Elasticsearch enabled setting path.conf as a setting. This was rather convoluted as it meant that you could start Elasticsearch with a config file that specified via path.conf that Elasticsearch should use another config file. Instead, to configure a custom config directory, use the ES_PATH_CONF environment variable.

As now all config files are expected to be at the path set on that variable jvm.options has to be copied to home/search/ instead of remaining in install/elasticsearch/config/

The service and upstart configuration has been updated to set the Environment variable or use the path.conf for older versions.
