### PR TITLE
Feature/cache clear

### DIFF
--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1,3 +1,19 @@
+Release 0.63, 28th April 2020
+-----------------------------
+
+Modified bamboo/jira "42disable_tomcat_access_logging" logic, added the ability to skip logging management all together, this is usefull as trying to
+manage the configuration (either to enable or disable) when the XML element(s) has been removed will cause the XML configuration document to be malformed.  
+This functionality is controlled via the SKIP_LOGGING_MANAGEMENT flag, a value of 1 means that logging will not be managed by avst-app, any other value means it will (defaults to 0)
+
+Added support to cleanup plugin caches and the home temp directory on startup in jira and confluence.
+
+This functionality is controlled by two new flags:
+* CLEAN_PLUGIN_CACHE - This flag determines if the plugin cache folders are cleared before the application starts, a value of 
+                       1 means yes and anything else means no (defaults to 0)
+* CLEAN_HOME_TEMP    - This flag determines if the temp directory in home is emptied before the application starts, a value of 
+                       1 means yes and anything else means no (defaults to 0)
+
+
 Release 0.62, 25th November 2019
 --------------------------------
 

--- a/share/avst-app/lib/product/bamboo/modify.d/42disable_tomcat_access_logging
+++ b/share/avst-app/lib/product/bamboo/modify.d/42disable_tomcat_access_logging
@@ -13,34 +13,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [[ ${REMOVE_TOMCAT_ACCESS_LOGGING:-0} -eq "0" ]]; then
-    ENABLE_TOMCAT_LOGGING='true'
+# if we are not managing the tomcat logging at all then do nothing to the config and print an informative debug message
+if [[ ${SKIP_LOGGING_MANAGEMENT:-0} -eq "1" ]]; then
+    warn "bamboo/modify.d/42disable_tomcat_access_logging: logging management disabled"
 else
-    ENABLE_TOMCAT_LOGGING='false'
-fi
-VALVES_COUNT=`grep \<Valve ${SERVER_XML_FILE} | wc -l`
-if [[ ${VALVES_COUNT:-0} -eq 0 ]]; then
-    warn "bamboo/modify.d/42disable_tomcat_access_logging: No Valve element found in ${SERVER_XML_FILE}."
-else
-    if [[ ${VALVES_COUNT:-0} -eq 1 ]]; then 
-            REMOVE_TOMCAT_ACCESS_LOGGING_CMD="set \$service/Engine/Valve/#attribute/enabled ${ENABLE_TOMCAT_LOGGING}"
+    if [[ ${REMOVE_TOMCAT_ACCESS_LOGGING:-0} -eq "0" ]]; then
+        ENABLE_TOMCAT_LOGGING='true'
     else
-    REMOVE_TOMCAT_ACCESS_LOGGING_CMD="set \$service/Engine/Valve[1]/#attribute/enabled ${ENABLE_TOMCAT_LOGGING}"
-            for (( i = 2; i <= ${VALVES_COUNT}; i++ )); do
-                    REMOVE_TOMCAT_ACCESS_LOGGING_CMD=$(printf "${REMOVE_TOMCAT_ACCESS_LOGGING_CMD}\n\
-    set \$service/Engine/Valve[${i}]/#attribute/enabled ${ENABLE_TOMCAT_LOGGING}")
-            done
+        ENABLE_TOMCAT_LOGGING='false'
     fi
+    VALVES_COUNT=`grep \<Valve ${SERVER_XML_FILE} | wc -l`
+    if [[ ${VALVES_COUNT:-0} -eq 0 ]]; then
+        warn "bamboo/modify.d/42disable_tomcat_access_logging: No Valve element found in ${SERVER_XML_FILE}."
+    else
+        if [[ ${VALVES_COUNT:-0} -eq 1 ]]; then
+                REMOVE_TOMCAT_ACCESS_LOGGING_CMD="set \$service/Engine/Valve/#attribute/enabled ${ENABLE_TOMCAT_LOGGING}"
+        else
+        REMOVE_TOMCAT_ACCESS_LOGGING_CMD="set \$service/Engine/Valve[1]/#attribute/enabled ${ENABLE_TOMCAT_LOGGING}"
+                for (( i = 2; i <= ${VALVES_COUNT}; i++ )); do
+                        REMOVE_TOMCAT_ACCESS_LOGGING_CMD=$(printf "${REMOVE_TOMCAT_ACCESS_LOGGING_CMD}\n\
+        set \$service/Engine/Valve[${i}]/#attribute/enabled ${ENABLE_TOMCAT_LOGGING}")
+                done
+        fi
 
-    augtool -LA ${AUGTOOL_DEBUG} <<EOF
-    set /augeas/load/xml/lens "Xml.lns"
-    set /augeas/load/xml/incl "${SERVER_XML_FILE}"
-    load
-    defvar server_xml "/files/${SERVER_XML_FILE}"
-    defvar service \$server_xml/Server/Service
-    print \$service/Engine
-    ${REMOVE_TOMCAT_ACCESS_LOGGING_CMD}
-    save
-    print /augeas//error
+        augtool -LA ${AUGTOOL_DEBUG} <<EOF
+        set /augeas/load/xml/lens "Xml.lns"
+        set /augeas/load/xml/incl "${SERVER_XML_FILE}"
+        load
+        defvar server_xml "/files/${SERVER_XML_FILE}"
+        defvar service \$server_xml/Server/Service
+        print \$service/Engine
+        ${REMOVE_TOMCAT_ACCESS_LOGGING_CMD}
+        save
+        print /augeas//error
 EOF
+    fi
 fi

--- a/share/avst-app/lib/product/confluence/start.d/80_clean_plugin
+++ b/share/avst-app/lib/product/confluence/start.d/80_clean_plugin
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright 2020 Adaptavist.com Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+remove_conf_plugin_dir() {
+	# if we have been passed an argument
+    if [[ ! -z ${1:-} ]]; then
+    	# and if the directory exists
+    	REMOVE_DIR="${HOME_DIR}/${1}"
+        if [[ -d "${REMOVE_DIR}" ]]; then
+            # remove it
+            debug "confluence/start/clean_plugin: Removing ${REMOVE_DIR}"
+            rm -rf "${REMOVE_DIR}"
+        fi
+    fi
+}
+
+# define list of directories that should be removed
+CONF_PLUGIN_REMOVE_DIRS=(bundled-plugins plugins-cache plugins-osgi-cache plugins-temp bundled-plugins_language)
+
+# if the CLEAN_PLUGIN_CACHE flag is set to 1 (true) then delete the plugin cache directories (as long as they exist)
+if [[  "${CLEAN_PLUGIN_CACHE:-0}" -eq 1 ]]; then
+	debug "confluence/start/clean_plugin: Attempting to clean Plugin Caches"
+
+    # loop through all directories and attempt to remove    
+    for REMOVE in ${CONF_PLUGIN_REMOVE_DIRS[@]}; do
+        remove_conf_plugin_dir "$REMOVE"
+    done
+
+fi

--- a/share/avst-app/lib/product/confluence/start.d/81_clean_tmp
+++ b/share/avst-app/lib/product/confluence/start.d/81_clean_tmp
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2020 Adaptavist.com Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# if the CLEAN_HOME_TEMP flag is set to 1 (true) then clean the directories (as long as they exist)
+if [[  "${CLEAN_HOME_TEMP:-0}" -eq 1 ]]; then
+	debug "confluence/start/clean_temp: Attempting to clean Home Temp directory"
+
+    # attempt to remove contents of temp from home
+    REMOVE_DIR="${HOME_DIR}/temp"
+    if [[ -d "${REMOVE_DIR}" ]]; then
+        debug "confluence/start/clean_temp: Clearing content of ${REMOVE_DIR}"
+        find "${REMOVE_DIR}" -mindepth 1 -maxdepth 1 -print0 | \
+        su - "${INSTANCE_USER}" -c "xargs -0rP 10 rm -rf"
+    fi
+
+fi

--- a/share/avst-app/lib/product/jira/modify.d/42disable_tomcat_access_logging
+++ b/share/avst-app/lib/product/jira/modify.d/42disable_tomcat_access_logging
@@ -13,34 +13,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [[ ${REMOVE_TOMCAT_ACCESS_LOGGING:-0} -eq "0" ]]; then
-    ENABLE_TOMCAT_LOGGING='true'
+# if we are not managing the tomcat logging at all then do nothing to the config and print an informative debug message
+if [[ ${SKIP_LOGGING_MANAGEMENT:-0} -eq "1" ]]; then
+    warn "jira/modify.d/42disable_tomcat_access_logging: logging management disabled"
 else
-    ENABLE_TOMCAT_LOGGING='false'
-fi
-VALVES_COUNT=`grep \<Valve ${SERVER_XML_FILE} | wc -l`
-if [[ ${VALVES_COUNT:-0} -eq 0 ]]; then
-    warn "bamboo/modify.d/42disable_tomcat_access_logging: No Valve element found in ${SERVER_XML_FILE}."
-else
-    if [[ ${VALVES_COUNT:-0} -eq 1 ]]; then 
-            REMOVE_TOMCAT_ACCESS_LOGGING_CMD="set \$service/Engine/Valve/#attribute/enabled ${ENABLE_TOMCAT_LOGGING}"
+    if [[ ${REMOVE_TOMCAT_ACCESS_LOGGING:-0} -eq "0" ]]; then
+        ENABLE_TOMCAT_LOGGING='true'
     else
-    REMOVE_TOMCAT_ACCESS_LOGGING_CMD="set \$service/Engine/Valve[1]/#attribute/enabled ${ENABLE_TOMCAT_LOGGING}"
-            for (( i = 2; i <= ${VALVES_COUNT}; i++ )); do
-                    REMOVE_TOMCAT_ACCESS_LOGGING_CMD=$(printf "${REMOVE_TOMCAT_ACCESS_LOGGING_CMD}\n\
-    set \$service/Engine/Valve[${i}]/#attribute/enabled ${ENABLE_TOMCAT_LOGGING}")
-            done
+        ENABLE_TOMCAT_LOGGING='false'
     fi
+    VALVES_COUNT=`grep \<Valve ${SERVER_XML_FILE} | wc -l`
+    if [[ ${VALVES_COUNT:-0} -eq 0 ]]; then
+        warn "jira/modify.d/42disable_tomcat_access_logging: No Valve element found in ${SERVER_XML_FILE}."
+    else
+        if [[ ${VALVES_COUNT:-0} -eq 1 ]]; then
+                REMOVE_TOMCAT_ACCESS_LOGGING_CMD="set \$service/Engine/Valve/#attribute/enabled ${ENABLE_TOMCAT_LOGGING}"
+        else
+        REMOVE_TOMCAT_ACCESS_LOGGING_CMD="set \$service/Engine/Valve[1]/#attribute/enabled ${ENABLE_TOMCAT_LOGGING}"
+                for (( i = 2; i <= ${VALVES_COUNT}; i++ )); do
+                        REMOVE_TOMCAT_ACCESS_LOGGING_CMD=$(printf "${REMOVE_TOMCAT_ACCESS_LOGGING_CMD}\n\
+        set \$service/Engine/Valve[${i}]/#attribute/enabled ${ENABLE_TOMCAT_LOGGING}")
+                done
+        fi
 
-    augtool -LA ${AUGTOOL_DEBUG} <<EOF
-    set /augeas/load/xml/lens "Xml.lns"
-    set /augeas/load/xml/incl "${SERVER_XML_FILE}"
-    load
-    defvar server_xml "/files/${SERVER_XML_FILE}"
-    defvar service \$server_xml/Server/Service
-    print \$service/Engine
-    ${REMOVE_TOMCAT_ACCESS_LOGGING_CMD}
-    save
-    print /augeas//error
+        augtool -LA ${AUGTOOL_DEBUG} <<EOF
+        set /augeas/load/xml/lens "Xml.lns"
+        set /augeas/load/xml/incl "${SERVER_XML_FILE}"
+        load
+        defvar server_xml "/files/${SERVER_XML_FILE}"
+        defvar service \$server_xml/Server/Service
+        print \$service/Engine
+        ${REMOVE_TOMCAT_ACCESS_LOGGING_CMD}
+        save
+        print /augeas//error
 EOF
+    fi
 fi

--- a/share/avst-app/lib/product/jira/start.d/80_clean_plugin
+++ b/share/avst-app/lib/product/jira/start.d/80_clean_plugin
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright 2020 Adaptavist.com Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+remove_jira_plugin_dir() {
+	# if we have been passed an argument
+    if [[ ! -z ${1:-} ]]; then
+    	# and if the directory exists
+    	REMOVE_DIR="${HOME_DIR}/plugins/${1}"
+        if [[ -d "${REMOVE_DIR}" ]]; then
+            # remove it
+            debug "jira/start/clean_plugin: Removing ${REMOVE_DIR}"
+            rm -rf "${REMOVE_DIR}"
+        fi
+    fi
+}
+
+# define list of directories that should be removed
+JIRA_PLUGIN_REMOVE_DIRS=(.bundled-plugins .osgi-plugins)
+
+# if the CLEAN_PLUGIN_CACHE flag is set to 1 (true) then delete the plugin cache directories (as long as they exist)
+if [[  "${CLEAN_PLUGIN_CACHE:-0}" -eq 1 ]]; then
+	debug "jira/start/clean_plugin: Attempting to clean Plugin Caches"
+
+    # loop through all directories and attempt to remove    
+    for REMOVE in ${JIRA_PLUGIN_REMOVE_DIRS[@]}; do
+        remove_jira_plugin_dir "$REMOVE"
+    done
+fi

--- a/share/avst-app/lib/product/jira/start.d/81_clean_tmp
+++ b/share/avst-app/lib/product/jira/start.d/81_clean_tmp
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2020 Adaptavist.com Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# if the CLEAN_HOME_TEMP flag is set to 1 (true) then clean the directories (as long as they exist)
+if [[  "${CLEAN_HOME_TEMP:-0}" -eq 1 ]]; then
+        debug "jira/start/clean_temp: Attempting to clean Home Temp directory"
+
+    # attempt to remove contents of temp from home
+    REMOVE_DIR="${HOME_DIR}/tmp"
+    if [[ -d "${REMOVE_DIR}" ]]; then
+        debug "jira/start/clean_temp_work: Clearing content of ${REMOVE_DIR}"
+        find "${REMOVE_DIR}" -mindepth 1 -maxdepth 1 -print0 | \
+        su - "${INSTANCE_USER}" -c "xargs -0rP 10 rm -rf"
+    fi
+fi


### PR DESCRIPTION
modified bamboo/jira "42disable_tomcat_access_logging", added the ability to skip logging management all together via the SKIP_LOGGING_MANAGEMENT flag, a value of 1 means that logging will not be managed by avst-app, any other value means it will (defaults to 0)

added logic to delete plugin cache dirs and home temp if instructed to do so, this functionality is controlled by two new flags:
* CLEAN_PLUGIN_CACHE - This flag determines if the plugin cache folders are cleared before the application starts, a value of 
                       1 means yes and anything else means no (defaults to 0)
* CLEAN_HOME_TEMP    - This flag determines if the temp directory in home is emptied before the application starts, a value of 
                       1 means yes and anything else means no (defaults to 0)