### PR TITLE
jira psql schema-name addition and mysql validation-query-timeout fix

### DIFF
--- a/release-notes.txt
+++ b/release-notes.txt
@@ -6,6 +6,9 @@ Added support for setting <schema-name></schema-name> in jira dbconfig.xml if th
 
 This is controlled by the DB_SCHEMA_NAME avst-app.cfg.sh variable, the default value of which is nothing and results in the element not being set
 
+In addition the logic to set "validation-query-timeout" for MySQL databases has been extended to any database type starting "mysql" instead of an exact match
+for just "mysql", this allows the mysql57 database type to also set the "validation-query-timeout" element
+
 
 Release 0.65, 26th Aug 2020
 ---------------------------

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1,3 +1,12 @@
+
+Release 0.66, 22nd Feb 2022
+---------------------------
+
+Added support for setting <schema-name></schema-name> in jira dbconfig.xml if the database type is postgres and a schema name is set.
+
+This is controlled by the DB_SCHEMA_NAME avst-app.cfg.sh variable, the default value of which is nothing and results in the element not being set
+
+
 Release 0.65, 26th Aug 2020
 ---------------------------
 

--- a/share/avst-app/lib/product/jira/modify.d/70setup_db
+++ b/share/avst-app/lib/product/jira/modify.d/70setup_db
@@ -60,7 +60,7 @@ EOF
   fi
 
   # if the DB is mysql add validation-query-timeout, if not do not
-  if [[ "${DB_TYPE}" == "mysql" ]]; then
+  if [[ "${DB_TYPE}" == mysql* ]]; then
     debug "jira/modify/setup_db: MySQL detected, setting validation-query-timeout"
     VAL_QUERY_TIMEOUT_SET="set \$datasources/validation-query-timeout/#text \"${DB_VALIDATION_QUERY_TIMEOUT:-3}\"" 
   else

--- a/share/avst-app/lib/product/jira/modify.d/70setup_db
+++ b/share/avst-app/lib/product/jira/modify.d/70setup_db
@@ -68,6 +68,15 @@ EOF
     VAL_QUERY_TIMEOUT_SET=""
   fi
 
+  # if this is postgres and a DB Schema Name is provided, set it
+  if [[ -n ${DB_SCHEMA_NAME:-} &&  "${DB_TYPE}" == postgres* ]]; then
+      debug "jira/modify/setup_db: PostgreSQL database type and a DB Schema Name value detected, setting schema-name attribute to ${DB_SCHEMA_NAME}"
+      DB_SCHEMA_NAME_SET="set \$database_config/schema-name/#text \"${DB_SCHEMA_NAME}\""
+  else
+      debug "jira/modify/setup_db: Not setting schema-name attribute"
+      DB_SCHEMA_NAME_SET=""
+  fi
+
   # TODO: Create variables from default values and adjust Note above and augtool code
   augtool -LA -e <<EOF
 set /augeas/load/xml/lens "Xml.lns"
@@ -79,6 +88,7 @@ defvar datasources \$database_config/jdbc-datasource
 set \$database_config/name/#text "${DB_DATASOURCE_NAME:-defaultDS}"
 set \$database_config/delegator-name/#text "${DB_DELEGATOR_NAME:-default}"
 set \$database_config/database-type/#text "${DB_TYPE}"
+${DB_SCHEMA_NAME_SET}
 set \$datasources/url/#text "${DB_JDBC_URL}"
 set \$datasources/driver-class/#text "${DB_DRIVER}"
 set \$datasources/username/#text "${DB_USERNAME}"


### PR DESCRIPTION
added postgres "schema-name" element into dbconfig if set by the user, also extended mysql validation-query-timeout logic to work with any db type starting mysql