### PR TITLE
converted calls that run stuff as the instance user from 'su' to 'sudo'

### DIFF
--- a/share/avst-app/lib/product/bamboo_agent/install.d/04extract_jar
+++ b/share/avst-app/lib/product/bamboo_agent/install.d/04extract_jar
@@ -16,7 +16,7 @@
 debug "install/extract_jar: Extracting '${INSTALL_DIR}/bamboo-agent-installer.jar'"
 if [[ "${VERSION:-}" == "" ]]; then
     debug "VERSION not specified, defaulting to installing the agent without AGENT_SECURITY_TOKEN"
-    EXTRACT_JAR_RESULT=$( run_cmd su - "${INSTANCE_USER}" -c \"java -Dbamboo.home=\\\"${HOME_DIR}\\\" -Ddisable_agent_auto_capability_detection=true -jar \\\"${INSTALL_DIR}/bamboo-agent-installer.jar\\\" \\\"${BAMBOO_SERVER}/agentServer\\\" install\" )
+    EXTRACT_JAR_RESULT=$( run_cmd sudo -u "${INSTANCE_USER}" bash -c \"java -Dbamboo.home=\\\"${HOME_DIR}\\\" -Ddisable_agent_auto_capability_detection=true -jar \\\"${INSTALL_DIR}/bamboo-agent-installer.jar\\\" \\\"${BAMBOO_SERVER}/agentServer\\\" install\" )
 else
     VERSIONS_COMPARED_RESULT=$( run_cmd "version_comparison '5.10.0' '<' '${VERSION}'" )
     if [[ "$(get_std_return ${VERSIONS_COMPARED_RESULT})" == "0" ]]; then
@@ -26,9 +26,9 @@ else
         else
             SECURITY_TOKEN_PARAM="-t ${AGENT_SECURITY_TOKEN}"
         fi
-        EXTRACT_JAR_RESULT=$( run_cmd su - "${INSTANCE_USER}" -c \"java -Dbamboo.home=\\\"${HOME_DIR}\\\" -Ddisable_agent_auto_capability_detection=true -jar \\\"${INSTALL_DIR}/bamboo-agent-installer.jar\\\" \\\"${BAMBOO_SERVER}/agentServer\\\" ${SECURITY_TOKEN_PARAM} install\" )
+        EXTRACT_JAR_RESULT=$( run_cmd sudo -u "${INSTANCE_USER}" bash -c \"java -Dbamboo.home=\\\"${HOME_DIR}\\\" -Ddisable_agent_auto_capability_detection=true -jar \\\"${INSTALL_DIR}/bamboo-agent-installer.jar\\\" \\\"${BAMBOO_SERVER}/agentServer\\\" ${SECURITY_TOKEN_PARAM} install\" )
     else
-        EXTRACT_JAR_RESULT=$( run_cmd su - "${INSTANCE_USER}" -c \"java -Dbamboo.home=\\\"${HOME_DIR}\\\" -Ddisable_agent_auto_capability_detection=true -jar \\\"${INSTALL_DIR}/bamboo-agent-installer.jar\\\" \\\"${BAMBOO_SERVER}/agentServer\\\" install\" )
+        EXTRACT_JAR_RESULT=$( run_cmd sudo -u "${INSTANCE_USER}" bash -c \"java -Dbamboo.home=\\\"${HOME_DIR}\\\" -Ddisable_agent_auto_capability_detection=true -jar \\\"${INSTALL_DIR}/bamboo-agent-installer.jar\\\" \\\"${BAMBOO_SERVER}/agentServer\\\" install\" )
     fi
 fi
 debug "${EXTRACT_JAR_RESULT}"

--- a/share/avst-app/lib/product/bamboo_agent/start.d/99run
+++ b/share/avst-app/lib/product/bamboo_agent/start.d/99run
@@ -16,7 +16,7 @@
 debug "start/run: Starting agent using '${INSTALL_DIR}/bamboo-agent-installer.jar'"
 if [[ "${VERSION:-}" == "" ]]; then
     debug "VERSION not specified, defaulting to starting the agent without AGENT_SECURITY_TOKEN"
-    START_AGENT_CMD=$( run_cmd su - "${INSTANCE_USER}" -c \"java -Dbamboo.home=\\\"${HOME_DIR}\\\" -Ddisable_agent_auto_capability_detection=true -jar \\\"${INSTALL_DIR}/bamboo-agent-installer.jar\\\" console\" )
+    START_AGENT_CMD=$( run_cmd sudo -u "${INSTANCE_USER}" bash -c \"java -Dbamboo.home=\\\"${HOME_DIR}\\\" -Ddisable_agent_auto_capability_detection=true -jar \\\"${INSTALL_DIR}/bamboo-agent-installer.jar\\\" console\" )
 else
     VERSIONS_COMPARED_RESULT=$( run_cmd "version_comparison '5.10.0' '<' '${VERSION}'" )
     if [[ "$(get_std_return ${VERSIONS_COMPARED_RESULT})" == "0" ]]; then
@@ -26,10 +26,10 @@ else
         else
             SECURITY_TOKEN_PARAM="-t ${AGENT_SECURITY_TOKEN}"
         fi
-        START_AGENT_CMD=$( run_cmd su - "${INSTANCE_USER}" -c \"java -Dbamboo.home=\\\"${HOME_DIR}\\\" -Ddisable_agent_auto_capability_detection=true -jar \\\"${INSTALL_DIR}/bamboo-agent-installer.jar\\\" \\\"${BAMBOO_SERVER}/agentServer\\\" ${SECURITY_TOKEN_PARAM} console\" )
+        START_AGENT_CMD=$( run_cmd sudo -u "${INSTANCE_USER}" bash -c \"java -Dbamboo.home=\\\"${HOME_DIR}\\\" -Ddisable_agent_auto_capability_detection=true -jar \\\"${INSTALL_DIR}/bamboo-agent-installer.jar\\\" \\\"${BAMBOO_SERVER}/agentServer\\\" ${SECURITY_TOKEN_PARAM} console\" )
     else
         debug "Version lower than 5.10.0, AGENT_SECURITY_TOKEN not required"
-        START_AGENT_CMD=$( run_cmd su - "${INSTANCE_USER}" -c \"java -Dbamboo.home=\\\"${HOME_DIR}\\\" -Ddisable_agent_auto_capability_detection=true -jar \\\"${INSTALL_DIR}/bamboo-agent-installer.jar\\\" console\" )
+        START_AGENT_CMD=$( run_cmd sudo -u "${INSTANCE_USER}" bash -c \"java -Dbamboo.home=\\\"${HOME_DIR}\\\" -Ddisable_agent_auto_capability_detection=true -jar \\\"${INSTALL_DIR}/bamboo-agent-installer.jar\\\" console\" )
     fi
 fi
 

--- a/share/avst-app/lib/product/bamboo_agent/stop.d/99stop
+++ b/share/avst-app/lib/product/bamboo_agent/stop.d/99stop
@@ -15,7 +15,7 @@
 
 debug "bamboo_agent/stop/run: Stopping agent using '${INSTALL_DIR}/bamboo-agent-installer.jar'"
 
-STOP_AGENT_CMD=$( run_cmd su - "${INSTANCE_USER}" -c \"java -Dbamboo.home=\\\"${HOME_DIR}\\\" \
+STOP_AGENT_CMD=$( run_cmd sudo -u "${INSTANCE_USER}" bash -c \"java -Dbamboo.home=\\\"${HOME_DIR}\\\" \
 	-Ddisable_agent_auto_capability_detection=true -jar \
 	\\\"${INSTALL_DIR}/bamboo-agent-installer.jar\\\" stop\" )
 debug "${STOP_AGENT_CMD}"

--- a/share/avst-app/lib/product/confluence/start.d/81_clean_tmp
+++ b/share/avst-app/lib/product/confluence/start.d/81_clean_tmp
@@ -22,7 +22,7 @@ if [[  "${CLEAN_HOME_TEMP:-0}" -eq 1 ]]; then
     if [[ -d "${REMOVE_DIR}" ]]; then
         debug "confluence/start/clean_temp: Clearing content of ${REMOVE_DIR}"
         find "${REMOVE_DIR}" -mindepth 1 -maxdepth 1 -print0 | \
-        su - "${INSTANCE_USER}" -c "xargs -0rP 10 rm -rf"
+        sudo -u "${INSTANCE_USER}" bash -c "xargs -0rP 10 rm -rf"
     fi
 
 fi

--- a/share/avst-app/lib/product/coverity/install.d/03execute_installer
+++ b/share/avst-app/lib/product/coverity/install.d/03execute_installer
@@ -93,8 +93,8 @@ set -e
 # As quiet installer does not work well with external db, we are installing the application 
 # via their command line wizard. The install_answers provides step by step answers to different options 
 # required by wizard. 
-install_answers | su - "${INSTANCE_USER}" -c "${INSTALLER}" 
+install_answers | sudo -u "${INSTANCE_USER}" bash -c "${INSTALLER}" 
 
 # install will automatically start service, we do not want it as we will use our own start script
-su - "${INSTANCE_USER}" -c "${INSTANCE_DIR}/install/bin/cov-im-ctl stop"
+sudo -u "${INSTANCE_USER}" bash -c "${INSTANCE_DIR}/install/bin/cov-im-ctl stop"
 

--- a/share/avst-app/lib/product/fisheye/start.d/99run
+++ b/share/avst-app/lib/product/fisheye/start.d/99run
@@ -19,5 +19,5 @@ RUN_CMD="exec -a \"${INSTANCE_NAME}\" ${JAVA_BIN} ${JAVA_OPTS} \
 
 debug "tomcat/start/run Running: ${RUN_CMD}"
 
-su "${INSTANCE_USER}" bash -c "${RUN_CMD}"
+sudo -u "${INSTANCE_USER}" bash -c "${RUN_CMD}"
 

--- a/share/avst-app/lib/product/jira/start.d/81_clean_tmp
+++ b/share/avst-app/lib/product/jira/start.d/81_clean_tmp
@@ -22,6 +22,6 @@ if [[  "${CLEAN_HOME_TEMP:-0}" -eq 1 ]]; then
     if [[ -d "${REMOVE_DIR}" ]]; then
         debug "jira/start/clean_temp_work: Clearing content of ${REMOVE_DIR}"
         find "${REMOVE_DIR}" -mindepth 1 -maxdepth 1 -print0 | \
-        su - "${INSTANCE_USER}" -c "xargs -0rP 10 rm -rf"
+        sudo -u "${INSTANCE_USER}" bash -c "xargs -0rP 10 rm -rf"
     fi
 fi

--- a/share/avst-app/lib/product/sonarqube/start.d/99run
+++ b/share/avst-app/lib/product/sonarqube/start.d/99run
@@ -28,4 +28,4 @@ RUN_CMD="\"${WRAPPER_DIR}/sonar.sh\" start"
 
 debug "sonarqube/start/run Running: ${RUN_CMD}"
 
-su "${INSTANCE_USER}" bash -c "${RUN_CMD}"
+sudo -u "${INSTANCE_USER}" bash -c "${RUN_CMD}"

--- a/share/avst-app/lib/product/sonarqube/stop.d/99stop
+++ b/share/avst-app/lib/product/sonarqube/stop.d/99stop
@@ -24,7 +24,7 @@ else
     fi
 fi
 
-RUN_CMD="su \"${INSTANCE_USER}\" bash -c \"${WRAPPER_DIR}/sonar.sh stop\""
+RUN_CMD="sudo -u \"${INSTANCE_USER}\" bash -c \"${WRAPPER_DIR}/sonar.sh stop\""
 
 debug "sonarqube/stop/stop: Running: ${RUN_CMD}"
 

--- a/share/avst-app/lib/product/synchrony/start.d/99run
+++ b/share/avst-app/lib/product/synchrony/start.d/99run
@@ -22,4 +22,4 @@ RUN_CMD="\"${INSTALL_DIR}/start-synchrony.sh\" -fg"
 
 debug "synchrony/start/run Running: ${RUN_CMD}"
 
-su "${INSTANCE_USER}" bash -c "${RUN_CMD}"
+sudo -u "${INSTANCE_USER}" bash -c "${RUN_CMD}"

--- a/share/avst-app/lib/product/synchrony/stop.d/99stop
+++ b/share/avst-app/lib/product/synchrony/stop.d/99stop
@@ -18,7 +18,7 @@ if [[ "$(uname)" != "Linux" ]]; then
     return 99
 fi
 
-RUN_CMD="su \"${INSTANCE_USER}\" bash -c \"${INSTALL_DIR}/stop-synchrony.sh\""
+RUN_CMD="sudo -u \"${INSTANCE_USER}\" bash -c \"${INSTALL_DIR}/stop-synchrony.sh\""
 
 debug "synchrony/stop/stop: Running: ${RUN_CMD}"
 

--- a/share/avst-app/lib/tomcat/start.d/02tomcat_clean_dirs
+++ b/share/avst-app/lib/tomcat/start.d/02tomcat_clean_dirs
@@ -17,7 +17,7 @@ for _dir in 'work' 'temp' ; do
     if [ -d "${TOMCAT_DIR}/${_dir}" ]; then
         debug "tomcat/modify/tomcat_clean_dirs: Clearing ${TOMCAT_DIR}/${_dir}"
         find "${TOMCAT_DIR}/${_dir}" -mindepth 1 -maxdepth 1 -print0 | \
-        su - "${INSTANCE_USER}" -c "xargs -0rP 10 rm -rf"
+        sudo -u "${INSTANCE_USER}" bash -c "xargs -0rP 10 rm -rf"
     fi
 done
 

--- a/share/avst-app/lib/tomcat/start.d/99run
+++ b/share/avst-app/lib/tomcat/start.d/99run
@@ -79,5 +79,5 @@ RUN_CMD="exec -a \"${INSTANCE_NAME}\" ${JAVA_BIN} $LOGGING_CONFIG ${JAVA_OPTS} $
 
 debug "tomcat/start/run Running: ${RUN_CMD}"
 
-su "${INSTANCE_USER}" bash -c "${RUN_CMD}"
+sudo -u "${INSTANCE_USER}" bash -c "${RUN_CMD}"
 

--- a/share/avst-app/lib/tomcat/stop.d/99stop
+++ b/share/avst-app/lib/tomcat/stop.d/99stop
@@ -48,7 +48,7 @@ CATALINA_TMPDIR="${CATALINA_HOME}/temp"
 
 TOMCAT_STOP_JAVA_OPTS="${TOMCAT_STOP_JAVA_OPTS:--Xms128m -Xmx512m -XX:MaxPermSize=256m}"
 
-RUN_CMD="su \"${INSTANCE_USER}\" bash -c \"exec -a \"${INSTANCE_NAME}_stop\" ${JAVA_BIN} $LOGGING_CONFIG ${TOMCAT_STOP_JAVA_OPTS} ${LOGGING_MANAGER} ${CATALINA_OPTS:-} \
+RUN_CMD="sudo -u \"${INSTANCE_USER}\" bash -c \"exec -a \"${INSTANCE_NAME}_stop\" ${JAVA_BIN} $LOGGING_CONFIG ${TOMCAT_STOP_JAVA_OPTS} ${LOGGING_MANAGER} ${CATALINA_OPTS:-} \
       -Djava.endorsed.dirs=${JAVA_ENDORSED_DIRS:-''} \
       -classpath $CLASSPATH \
       -Dcatalina.base=$CATALINA_BASE \


### PR DESCRIPTION
Swapped the method of running things as the instance user from using "su" to "sudo", this has a number of advantages but mainly means that we are not dependent on the user having an interactive shell (so can use /sbin/nologin or rssh).
Tested this change on with the following apps:
* bamboo
* bitbucket
* jira
* confluence
* fisheye/cruvible

On the Following Operating Systems:
* Vanilla CentOS-7
* CIS-L1 benchmark CentOS 7
* Ubuntu 18