### PR TITLE
logix fix to extract PSQL jar from conf 8+

### DIFF
--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1,3 +1,9 @@
+Release 0.73, 26th July 2023
+----------------------------
+
+Fixed the logic that extracts the PostgreSQL driver for standalone synchrony installs
+to work with the different naming convention used for the driver in Confluuence 8.0+
+
 Release 0.72, 15th May 2023
 ---------------------------
 

--- a/share/avst-app/lib/product/synchrony/install.d/03expand_tarball
+++ b/share/avst-app/lib/product/synchrony/install.d/03expand_tarball
@@ -27,7 +27,7 @@ fi
 VERSIONS_COMPARED_RESULT=$( run_cmd "version_comparison '6.4.99' '<' '${VERSION}'" )
 if [[ "$(get_std_return ${VERSIONS_COMPARED_RESULT})" == "0" ]]; then
     debug "synchrony/install.d/03expand_tarball: Confluence >=6.5 detected, including synchrony bin"
-    WILDCARDS_TO_EXTRACT="'*/bin/synchrony' '*/synchrony-standalone.jar' '*/postgresql-*.jar'"
+    WILDCARDS_TO_EXTRACT="'*/bin/synchrony' '*/synchrony-standalone.jar' '*/*postgresql-*.jar'"
 else
     debug "synchrony/install.d/03expand_tarball: Confluence <6.5 detected, excluding synchrony bin"
     WILDCARDS_TO_EXTRACT="'*/synchrony-standalone.jar' '*/postgresql-*.jar'"


### PR DESCRIPTION
Changed the extract logic for conf 6.5+ based systems  to be able to extract pre confluence 8 driver file name:
postgresql-42.5.0.jar

To also support extracting from  a confluence 8 driver file name:
org.postgresql_postgresql-42.5.3.jar